### PR TITLE
feat: Usable require()

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "serialize-javascript": "^5.0.1"
   },
   "devDependencies": {
+    "@semantic-release/changelog": "semantic-release/changelog",
+    "@semantic-release/git": "^9.0.0",
+    "@semantic-release/npm": "^7.1.3",
     "eslint": "^7.16.0",
     "eslint-config-airbnb-standard": "^3.1.0",
     "eslint-plugin-import": "^2.22.1",
@@ -40,10 +43,7 @@
     "eslint-plugin-react": "^7.23.2",
     "eslint-plugin-standard": "^5.0.0",
     "jest": "^26.6.3",
-    "semantic-release": "^17.4.4",
-    "@semantic-release/changelog": "semantic-release/changelog",
-    "@semantic-release/git": "^9.0.0",
-    "@semantic-release/npm": "^7.1.3"
+    "semantic-release": "^17.4.4"
   },
   "jest": {
     "testRegex": "./tests/.*.js$",

--- a/src/functions/bench.js
+++ b/src/functions/bench.js
@@ -1,6 +1,4 @@
 const { fork } = require('child_process');
-const Module = require('module');
-const serial = require('serialize-javascript');
 const Profiler = require('../classes/Profiler');
 const { getInternals, wrap } = require('../helpers/fnFormat');
 

--- a/src/functions/bench.js
+++ b/src/functions/bench.js
@@ -46,7 +46,7 @@ module.exports = async (func, args = [], opts = {}) => {
       requires += `const ${r.name} = global.process.mainModule.require('${r.path}');`;
     });
 
-    internals.fn = `${requires}\n${internals.fn}`;
+    formatted = `${requires}`;
   }
 
   formatted += wrap(internals.fn, internals.fnArgs);


### PR DESCRIPTION
While the parameter was there, the functionality for `require()` was not. After much digging, I finally found a solution.